### PR TITLE
Web-based changelog generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _site/*
 build/*
 Gemfile.lock
+_changelogs/*.*.md

--- a/_changelogs/index.md
+++ b/_changelogs/index.md
@@ -1,0 +1,14 @@
+---
+title: Changelog
+permalink: /changelog/
+---
+
+The contents of Sopel's [NEWS]({{ site.repo }}/blob/master/NEWS) file, until
+now only accessible via browsing the [GitHub repository]({{ site.repo }}), now
+automatically parsed and broken into pages for your reading pleasure.
+
+{% assign docs = site.changelogs | where_exp: "doc", "doc.url != page.url" | sort: "title" | reverse %}
+<ul>
+{% for doc in docs %}
+  <li><a href="{{ doc.url }}">{{ doc.title }}</a></li>
+{% endfor %}

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ exclude:
   - netlify-build.sh
   - runtime.txt
   - document_sopel_modules.py
+  - generate_changelogs.py
 
 include:
   - _redirects
@@ -25,6 +26,8 @@ collections:
   usage:
     output: true
   appendices:
+    output: true
+  changelogs:
     output: true
 
 defaults:
@@ -43,6 +46,11 @@ defaults:
     values:
       layout: article
       permalink: /appendix/:name/
+  - scope:
+      path: "_changelogs"
+    values:
+      layout: changelog
+      permalink: /changelog/:path/
   - scope:
       path: "_*/index.*"
     values:

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,49 +1,54 @@
 ---
 layout: default
 ---
-<article{% if page.migrated %} class="migrated"{% endif %}>
-  <a class="to-parent" href="../">Up a level</a>
-  <h1>{{ page.title }}</h1>{% if page.migrated and page.source == "wiki" %}
-  <aside>
-    <p>This article was migrated here from the old GitHub wiki.</p>
-    <p>It might be a little outdated and/or have a broken layout.</p>
-    <p>Your help fixing any errors is appreciated! <a href="https://github.com/sopel-irc/sopel-website/edit/wiki-migration/{{ page.path }}">Edit this page</a></p>
-  </aside>
-  {% endif %}{{ content }}{% if page.collection %}
-    {% unless page.is_index %}
-      {% assign list = site[page.collection] | where_exp: "item", "item.is_index != true" %}
-      {% if page.order %}
-        {% assign sortedList = list | sort: "order" %}
-      {% else %}
-        {% assign sortedList = list %}
+{% if page.collection %}
+  {% unless page.is_index %}
+    {% assign list = site[page.collection] | where_exp: "item", "item.is_index != true" %}
+    {% if page.order %}
+      {% assign sortedList = list | sort: "order" %}
+    {% else %}
+      {% assign sortedList = list %}
+    {% endif %}
+    {% for item in sortedList %}
+      {% if item.title == page.title %}
+        {% unless forloop.first %}
+          {% assign prevurl = prev.url %}
+          {% assign prevtitle = prev.title %}
+        {% endunless %}
+        {% unless forloop.last %}
+          {% assign next = sortedList[forloop.index] %}
+          {% assign nexturl = next.url %}
+          {% assign nexttitle = next.title %}
+        {% endunless %}
       {% endif %}
-      {% for item in sortedList %}
-        {% if item.title == page.title %}
-          {% unless forloop.first %}
-            {% assign prevurl = prev.url %}
-            {% assign prevtitle = prev.title %}
-          {% endunless %}
-          {% unless forloop.last %}
-            {% assign next = sortedList[forloop.index] %}
-            {% assign nexturl = next.url %}
-            {% assign nexttitle = next.title %}
-          {% endunless %}
-        {% endif %}
-        {% assign prev = item %}
-      {% endfor %}
-  <nav>
+      {% assign prev = item %}
+    {% endfor %}
+    {% capture navlinks %}
     <ul>
       {% if prevurl %}
       <li class="prevlink">
         <a href="{{ prevurl }}">{{ prevtitle }}</a>
       </li>
       {% endif %}
+      <li class="uplink"><a class="to-parent" href="../">Up a level</a></li>
       {% if nexturl %}
       <li class="nextlink">
         <a href="{{ nexturl }}">{{ nexttitle }}</a>
       </li>
       {% endif %}
     </ul>
-  </nav>
+    {% endcapture %}
   {% endunless %}
-{% endif %}</article>
+{% endif %}
+<article{% if page.migrated %} class="migrated"{% endif %}>
+  {% if navlinks %}<nav class="top">{{ navlinks }}</nav>{% endif %}
+  <h1>{{ page.title }}</h1>{% if page.migrated and page.source == "wiki" %}
+  <aside>
+    <p>This article was migrated here from the old GitHub wiki.</p>
+    <p>It might be a little outdated and/or have a broken layout.</p>
+    <p>Your help fixing any errors is appreciated! <a href="https://github.com/sopel-irc/sopel-website/edit/wiki-migration/{{ page.path }}">Edit this page</a></p>
+  </aside>
+  {% endif %}
+  {{ content }}
+  {% if navlinks %}<nav class="bottom">{{ navlinks }}</nav>{% endif %}
+</article>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -41,8 +41,9 @@ layout: default
   {% endunless %}
 {% endif %}
 <article{% if page.migrated %} class="migrated"{% endif %}>
+  <h1>{{ page.title }}</h1>
   {% if navlinks %}<nav class="top">{{ navlinks }}</nav>{% endif %}
-  <h1>{{ page.title }}</h1>{% if page.migrated and page.source == "wiki" %}
+  {% if page.migrated and page.source == "wiki" %}
   <aside>
     <p>This article was migrated here from the old GitHub wiki.</p>
     <p>It might be a little outdated and/or have a broken layout.</p>

--- a/_layouts/changelog.html
+++ b/_layouts/changelog.html
@@ -1,10 +1,7 @@
 ---
 layout: default
 ---
-<article{% if page.is_index %} class="column-list"{% endif %}>
-  <a class="to-parent" href="../">Up a level</a>
-  <h1>{{ page.title }}</h1>
-  {{ content }}{% if page.collection %}
+{% if page.collection %}
     {% unless page.is_index %}
       {% assign list = site[page.collection] | where_exp: "item", "item.is_index != true" %}
       {% if page.order %}
@@ -26,19 +23,26 @@ layout: default
         {% endif %}
         {% assign prev = item %}
       {% endfor %}
-  <nav>
+      {% capture navlinks %}
     <ul>
       {% if prevurl %}
       <li class="prevlink">
         <a href="{{ prevurl }}">{{ prevtitle }}</a>
       </li>
       {% endif %}
+      <li class="uplink"><a href="../">Up a level</a></li>
       {% if nexturl %}
       <li class="nextlink">
         <a href="{{ nexturl }}">{{ nexttitle }}</a>
       </li>
       {% endif %}
     </ul>
-  </nav>
+    {% endcapture %}
   {% endunless %}
-{% endif %}</article>
+{% endif %}
+<article{% if page.is_index %} class="column-list"{% endif %}>
+  {% if navlinks %}<nav class="top">{{ navlinks }}</nav>{% endif %}
+  <h1>{{ page.title }}</h1>
+  {{ content }}
+  {% if navlinks %}<nav class="bottom">{{ navlinks }}</nav>{% endif %}
+</article>

--- a/_layouts/changelog.html
+++ b/_layouts/changelog.html
@@ -41,8 +41,8 @@ layout: default
   {% endunless %}
 {% endif %}
 <article{% if page.is_index %} class="column-list"{% endif %}>
-  {% if navlinks %}<nav class="top">{{ navlinks }}</nav>{% endif %}
   <h1>{{ page.title }}</h1>
+  {% if navlinks %}<nav class="top">{{ navlinks }}</nav>{% endif %}
   {{ content }}
   {% if navlinks %}<nav class="bottom">{{ navlinks }}</nav>{% endif %}
 </article>

--- a/_layouts/changelog.html
+++ b/_layouts/changelog.html
@@ -1,0 +1,44 @@
+---
+layout: default
+---
+<article{% if page.is_index %} class="column-list"{% endif %}>
+  <a class="to-parent" href="../">Up a level</a>
+  <h1>{{ page.title }}</h1>
+  {{ content }}{% if page.collection %}
+    {% unless page.is_index %}
+      {% assign list = site[page.collection] | where_exp: "item", "item.is_index != true" %}
+      {% if page.order %}
+        {% assign sortedList = list | sort: "order" | reverse %}
+      {% else %}
+        {% assign sortedList = list | reverse %}
+      {% endif %}
+      {% for item in sortedList %}
+        {% if item.title == page.title %}
+          {% unless forloop.first %}
+            {% assign prevurl = prev.url %}
+            {% assign prevtitle = prev.title %}
+          {% endunless %}
+          {% unless forloop.last %}
+            {% assign next = sortedList[forloop.index] %}
+            {% assign nexturl = next.url %}
+            {% assign nexttitle = next.title %}
+          {% endunless %}
+        {% endif %}
+        {% assign prev = item %}
+      {% endfor %}
+  <nav>
+    <ul>
+      {% if prevurl %}
+      <li class="prevlink">
+        <a href="{{ prevurl }}">{{ prevtitle }}</a>
+      </li>
+      {% endif %}
+      {% if nexturl %}
+      <li class="nextlink">
+        <a href="{{ nexturl }}">{{ nexttitle }}</a>
+      </li>
+      {% endif %}
+    </ul>
+  </nav>
+  {% endunless %}
+{% endif %}</article>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,9 +43,10 @@
               <li><a href="{% link _tutorials/index.md %}">Tutorials</a></li>
               <li><a href="{% link _appendices/index.md %}">Appendix</a></li>
               <li><a href="{{ site.docs }}">API Documentation</a></li>
-              <li><a href="{% link download.md %}">Download</a></li>
               <li><a href="{{ site.repo }}/issues">Issue Tracker</a></li>
               <li><a href="{{ site.repo }}">Source Code</a></li>
+              <li><a href="{% link download.md %}">Download</a></li>
+              <li><a href="{% link _changelogs/index.md %}">Changelog</a></li>
             </ul>
           </header>
           <div class="content{% if page.center-text %} centered-text{% endif %}">

--- a/css/style.css
+++ b/css/style.css
@@ -136,11 +136,19 @@ header h2 {
 }
 
 .content article nav ul {
-    margin: 1em 0;
+    /* bottom navbar is the most used, and not always classed, *
+     * so these are the default measurements.                  */
+    margin: 2em 0 1em;
     padding: 0;
     display: flex;
     justify-content: space-between;
     position: relative;
+    font-size: smaller;
+}
+.content article nav.top ul {
+    /* navbar on top of a page is currently only for changelogs */
+    margin-top: 1em;
+    margin-bottom: 2em;
 }
 .content article nav ul li {
     display: inline;
@@ -157,10 +165,6 @@ header h2 {
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    font-size: smaller;
-}
-.content article nav.bottom ul li.uplink {
-    bottom: 0;
 }
 .content article nav ul li.nextlink {
     margin-left: auto;

--- a/css/style.css
+++ b/css/style.css
@@ -66,9 +66,6 @@ header h2 {
     border-bottom: 1px dotted #aaa;
     padding-bottom: 4px;
 }
-.content :first-child {
-    margin-top: 0.4em;
-}
 .content p {
     margin-bottom: 10px;
 }
@@ -159,6 +156,22 @@ header h2 {
 }
 .content article nav ul li.nextlink a:after {
     content: "→";
+}
+
+.content article.column-list ul {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    list-style: none;
+    padding: 0;
+    margin: auto 4em;
+}
+.content article.column-list ul li {
+    display: block;
+    width: 8em;
+    padding: 1em 1ex;
+    list-style: none;
 }
 
 .content article.migrated aside {

--- a/css/style.css
+++ b/css/style.css
@@ -140,6 +140,7 @@ header h2 {
     padding: 0;
     display: flex;
     justify-content: space-between;
+    position: relative;
 }
 .content article nav ul li {
     display: inline;
@@ -150,6 +151,16 @@ header h2 {
 }
 .content article nav ul li.prevlink a:before {
     content: "←";
+}
+.content article nav ul li.uplink {
+    display: inline-block;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: smaller;
+}
+.content article nav.bottom ul li.uplink {
+    bottom: 0;
 }
 .content article nav ul li.nextlink {
     margin-left: auto;

--- a/generate_changelogs.py
+++ b/generate_changelogs.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python2.7
+"""
+Sopel module documentation utility
+This script creates (either Markdown or reST) files, documenting the commands
+and module configuration options in a Sopel instance.
+
+Copyright 2012 Edward Powell, embolalia.net
+Copyright 2019 dgw, technobabbl.es
+Licensed under the Eiffel Forum License 2.
+
+https://sopel.chat
+"""
+import argparse
+import glob
+import inspect
+import os
+import re
+
+
+def main(argv=None):
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+
+    parser = argparse.ArgumentParser(
+        description="Sopel changelog page generation utility",
+        usage='%(prog)s [options]'
+        )
+    parser.add_argument(
+        '--news',
+        dest='news_file',
+        nargs='?',
+        help="Specify the location of the NEWS file to use.",
+        default=os.path.join(os.path.join(this_dir, '_sopel'), 'NEWS')
+        )
+    parser.add_argument(
+        '--clean',
+        action='store_true',
+        help="Clean up the generated changelog files."
+        )
+
+    if argv:
+        args = parser.parse_args(argv)
+    else:
+        args = parser.parse_args()
+
+    if args.clean:
+        print("Cleaning up changelog files...")
+        for entry in glob.glob('_changelogs/*.md'):
+            if not entry.endswith('index.md'):
+                os.remove(entry)
+        return
+
+    print("Generating changelog pages using NEWS file: " + args.news_file)
+    print("...")
+
+    with open(args.news_file, 'r') as f:
+        news = f.read()
+
+    split_news = re.split(r'Changes between \d+\.\d+(?:\.\d+)? and ', news)[1:]
+
+    versions = {}
+    for entry in split_news:
+        version = re.match('^(.+?)\n', entry).group(1)
+        body = re.search('(?s)\n=+\n(.*)', entry).group(1).strip()
+        versions.update( {version: body} )
+
+    for version, text in versions.items():
+        with open('_changelogs/{}.md'.format(version), 'w') as f:
+            f.write("---\ntitle: Version {version}\n---\n\n{log_entry}\n"
+                    .format(version=version, log_entry=text))
+
+    print("Done! {} versions documented.".format(len(versions.keys())))
+
+if __name__ == '__main__':
+    main()

--- a/netlify-build.sh
+++ b/netlify-build.sh
@@ -5,6 +5,9 @@ echo "Starting custom build script..."
 echo "Installing Sphinx"
 pip install sphinx
 
+echo "Generating changelogs"
+python generate_changelogs.py --news=_sopel/NEWS
+
 echo "Building Jekyll site"
 bundler exec jekyll build
 


### PR DESCRIPTION
Generates Markdown -> HTML changelog pages on site build from the `_sopel` submodule already used for auto-documenting modules and generating Sphinx docs.

There are a few known issues with this version:

  * The page permalinks use hyphens instead of dots due entirely to how Jekyll generates page names. There is probably a workaround, but I haven't found it yet.
  * Sopel's NEWS file isn't really Markdown-compliant. It's close enough that none of the pages I spot-checked are *broken* per se, but things like links don't work because of Kramdown (which doesn't autolink bare URLs; they MUST be wrapped in `<angle brackets>`). The best solution to this is probably going back and revising Sopel's NEWS file, since it's inconsistent in a lot of little ways, anyway. (Ultimately, Sopel's README should become Markdown instead of rST, too, so we're not dealing with too many different documentation formats. Both files could be revised at the same time.)

As a bonus, this removes a problematic CSS style that added a top margin to first-child elements within the `.content` frame. It was quite a puzzle tracking that down, because only the first item in the version list was misaligned... Whatever past version of myself thought that style was a good idea, I should go back in time and smack him.

----

Current task list for making this ready-to-go:

  - [x] Fix permalinks so we can have `/changelog/6.6.1/` instead of `/changelog/6-6-1/`
    * I'm sure this is doable by setting the `permalink:` value in YAML front matter from the generator script. It's not awful, because the pages _are_ auto-generated, but I do want to find a "nicer" workaround if one exists.
  - [ ] Go through NEWS file and make it proper Markdown
    * Can be done after launch; not a hard requirement for going live
    * Changing the section divider format is not required, because headings underlined with `===[…]===` (Setext-style) are actually part of the Markdown spec