### PR TITLE
Constrain prev/next link widths to avoid overlap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -148,6 +148,7 @@ header h2 {
 }
 .content article nav ul li.prevlink {
     margin-right: auto;
+    max-width: 30%;
 }
 .content article nav ul li.prevlink a:before {
     content: "←";
@@ -157,9 +158,11 @@ header h2 {
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
+    max-width: 30%;
 }
 .content article nav ul li.nextlink {
     margin-left: auto;
+    max-width: 30%;
 }
 .content article nav ul li.nextlink a:after {
     content: "→";


### PR DESCRIPTION
Noticed some ugly overlapping on mobile in portrait mode, because of the "Up a level" links being absolutely positioned for *reasons*.

Wanted to get rid of the absolute positioning with some fancy CSS selectors, but apparently such a thing (selecting an element with a certain number of children) doesn't exist. This will do instead.