### PR TITLE
Constrain content width for easier reading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,7 +51,8 @@ header h2 {
     font-family: 'Courgette', cursive;
 }
 .content {
-    width: 75%;
+    width: 80%;
+    max-width: 60em;
     margin: auto;
     background: #E0EBEB;
     border-radius: 1.5em;
@@ -189,7 +190,7 @@ header h2 {
     float: right;
     clear: right;
     width: fit-content;
-    max-width: 25%;
+    max-width: 30em;
     padding: 0.5em;
     padding-left: 80px;
     background-color: #ffb;
@@ -213,6 +214,7 @@ header h2 {
         background-position: center 12px, center, center;
         padding-left: 0.5em;
         padding-top: 80px;
+        max-width: 25%;
     }
 }
 .content article.migrated aside p {


### PR DESCRIPTION
Keeping the content pane from getting too wide makes reading the site easier on widescreen monitors, which could have extremely long lines under the old styles.

While this change narrows the content on most desktop monitors, it should slightly increase the usable width on mobile devices and lower-resolution displays.

Adjusted the notice box on migrated wiki pages to still look nice with the new page width setup.