### PR TITLE
Update system requirements for Sopel 7

### DIFF
--- a/_usage/system-requirements.md
+++ b/_usage/system-requirements.md
@@ -10,17 +10,16 @@ Sopel is designed to run on Linux with Python 2.7 or 3.3+. It should probably wo
 Sopel itself has few external dependencies, besides Python. There are a couple, though:
 
 * [dnspython](https://github.com/rthalley/dnspython) - used internally to enhance connection reliability
-* [requests](https://github.com/requests/requests) - used to maintain compatibility with old modules that still try to use Sopel's `web` utility functions
-* sqlite - included with all supported Python releases
+* [requests](https://github.com/requests/requests) - used to maintain compatibility with old plugins that use deprecated features of Sopel's `web` utility API
+* [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy) - used for database cross-compatibility (SQLite, MySQL, PostgreSQL, etc.)
 
-Most of Sopel's dependencies are only needed for specific modules. Below is a listing of some of these. If you don't want to use a specific module, you do not need its dependencies.
+Most of Sopel's dependencies are only needed for specific plugins. Below is a listing of some of these. If you don't want to use a specific plugin, you do not need its dependencies.
 
 * [geoip2](https://github.com/maxmind/GeoIP2-python) - ip. You will also need the appropriate database files, which Sopel will download automatically if they are not found.
-* [ipython](https://github.com/ipython/ipython) - ipython
+* [ipaddress](https://github.com/phihag/ipaddress) - url (only needed on Python 2)
 * [praw](https://github.com/praw-dev/praw) - reddit
-* [pyenchant](https://github.com/rfk/pyenchant) - spellcheck. You may also need to install the system-level `enchant` library.
 * [pytz](https://launchpad.net/pytz) - remind, clock, seen, tell
-* [requests](https://github.com/requests/requests) - [many]. Used by nearly every module that needs to talk to a web service.
+* [requests](https://github.com/requests/requests) - used by nearly every plugin that needs to talk to a web service. This includes both built-in and third-party plugins; you probably should just install this one.
 * [xmltodict](https://github.com/martinblech/xmltodict) - bugzilla, search
 
 Most of these packages can be installed through the `pip` command, or via your Linux distribution's software repository. If you install Sopel through `pip` or your distribution's package manager (on Fedora or Arch), all of these dependencies will be installed for you.


### PR DESCRIPTION
We're ditching `enchant` and moving the rewritten `spellcheck` plugin (now using `aspell`) into its own project. Same for `ipython`; the eponymous plugin, though not rewritten, is no longer part of the base Sopel distribution.

If either sopel-irc/sopel#1675 or sopel-irc/sopel#1684 gets bumped to a later release (unlikely) or rejected (even less likely), this will need tweaking.