### PR TITLE
css: increase line-height to 1.4

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -72,6 +72,9 @@ header h2 {
 .content p {
     margin-bottom: 10px;
 }
+.content p, .content li, .content dd {
+    line-height: 1.4;
+}
 
 .content dl.faq {
     margin: 0.5em 1em;


### PR DESCRIPTION
I was reading a preview of the Upgrading guide to Sopel 7, when I started to notice something annoying: paragraphs of multiple lines are sometimes difficult to read because of the lack of proper line height.

So, here I'm, doing a very small-diff PR to fix just that.