### PR TITLE
Remove duplicate CLI usage page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 *.sw*
+.jekyll-cache/*
 _site/*
 build/*
+docs/*
 Gemfile.lock
 _changelogs/*.*.md
 _usage/commands.md
 _usage/plugin-configuration.md
+latest.json

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,8 @@ exclude:
 
 include:
   - _redirects
+  # Can't use docs/_static - see jekyll/jekyll#1352
+  - _static
 
 collections:
   tutorials:

--- a/_redirects
+++ b/_redirects
@@ -3,12 +3,23 @@
 # Redirect default Netlify subdomain to primary domain
 https://sopel.netlify.com/* https://sopel.chat/:splat 301!
 
-# Auto-generated redirects for renamed pages based on YAML front-matter
+# YAML front-matter-based redirects for renamed pages
 {% for collection in site.collections
   %}{% for page in collection.docs
     %}{% for link in page.previously
       %}{{ link }} {{ page.url }} 301
 {%    endfor %}{%
+    endfor %}{%
+  endfor
+%}
+
+# YAML front-matter-based redirects from "deleted" pages to their replacements
+# The '!' makes them redirect even though the page exists
+{% for collection in site.collections
+  %}{% for page in collection.docs
+    %}{% if page.redirect_to
+      %}{{ page.url }}* {{ page.redirect_to }} 301!
+{%    endif %}{%
     endfor %}{%
   endfor
 %}

--- a/_usage/command-line-arguments.md
+++ b/_usage/command-line-arguments.md
@@ -3,25 +3,8 @@ title: Command-line arguments
 migrated: true
 source: wiki
 order: -9001
+redirect_to: /docs/cli.html
 ---
 
-Sopel's command-line arguments are as follows:
-
-<dl>
-  <dt><tt>-h</tt>, <tt>--help</tt></dt>
-  <dd>Show the help message and exit</dd>
-  <dt><tt>-l</tt>, <tt>--list</tt></dt>
-  <dd>List all available config files</dd>
-  <dt><tt>-c filename</tt>, <tt>--config filename</tt></dt>
-  <dd>Use the given config file. Path is relative to <tt>~/.sopel</tt>. If not given, <tt>default.cfg</tt> is assumed.</dd>
-  <dt><tt>-m</tt>, <tt>--migrate</tt></dt>
-  <dd>Migrate the current Sopel configuration file from the old <tt>.py</tt> format to the new <code>ConfigParser</code>-based <tt>.cfg</tt> format</dd>
-  <dt><tt>-d</tt>, <tt>--fork</tt></dt>
-  <dd>Run Sopel in the background. Output will still be shown unless <tt>--quiet</tt> is used.</dd>
-  <dt><tt>-q</tt>, <tt>--quit</tt></dt>
-  <dd>Tell a running Sopel to quit gracefully. (That is, send a QUIT message to the server before exiting.) This only affects the Sopel instance with the same config file — i.e. the same <tt>--config</tt> will need to be specified here if it was specified when you started Sopel.</dd>
-  <dt><tt>--quiet</tt></dt>
-  <dd>Suppress all terminal output</dd>
-  <dt><tt>-k</tt>, <tt>--kill</tt></dt>
-  <dd>Kill a running Sopel in an un-clean fashion (i.e. send SIGKILL to the process; no quit message will be sent to the server). Like <tt>--quit</tt>, the same <tt>--config</tt> must be specified here as when it was started, if any. Should only be used if Sopel does not respond to <tt>--quit</tt>.</dd>
-</dl>
+<!-- WARNING: Update both paths (`redirect_to` above and `link` below) in parallel! -->
+Sopel's command-line argument documentation has [moved]({% link /docs/cli.html %}).

--- a/netlify-build.sh
+++ b/netlify-build.sh
@@ -12,9 +12,6 @@ pip3 install ./_sopel
 echo "Generating plugin command/config pages"
 python3 document_sopel_plugins.py --sopel=_sopel
 
-echo "Building Jekyll site"
-jekyll build
-
 echo "Installing Sopel's dev dependencies"
 pip3 install -r ./_sopel/dev-requirements.txt
 
@@ -23,7 +20,10 @@ cd _sopel/docs
 make html
 cd ../../
 
-echo "Moving Sphinx docs to Jekyll output folder"
-mv _sopel/docs/build/html _site/docs
+echo "Moving Sphinx docs to Jekyll site folder for output"
+mv _sopel/docs/build/html/ docs/
+
+echo "Building Jekyll site"
+jekyll build
 
 echo "Finished custom build script!"


### PR DESCRIPTION
Summary of changes:

* Generate Sphinx `docs/` _before_ Jekyll runs so we can use `{% link %}` tags in Jekyll pages to reference docs now
  * Also necessitates a stupid `_config.yml` trick to include Sphinx's `_static` directory, since Jekyll doesn't understand subdirectories in the `include` setting (jekyll/jekyll#1352)
  * Future project: convert existing documentation links in the Jekyll site to use `link`
* Define a new type of auto-generated redirect in `_redirects` that redirects from an _existing_ page to somewhere else (including forcing Netlify to ignore the existing page and redirect anyway)
* Use the new redirect type to overwrite the outdated "Command-line arguments" page taken from the wiki in the Great Migration and point it at the automatically-updated Sphinx CLI docs instead
* Bonus: Tell Git to ignore some more build-artifact-y stuff