### PR TITLE
installing: Skip listing upgrade guides without version range

### DIFF
--- a/_usage/installing.md
+++ b/_usage/installing.md
@@ -70,6 +70,9 @@ to upgrade to the newest version, you should consult the migration guides.
 
 {% assign ups = site.upgrading | sort: "covers_to"
   %}{% for up in ups %}{%
+    unless up.covers_to and up.covers_from %}{%
+      continue %}{% comment %} Skips guides that aren't ready {% endcomment %}{%
+    endunless %}{%
     assign from_name = "Sopel" %}{%
     assign to_name = "Sopel" %}{%
     assign covers_from = up.covers_from | plus: 0 %}{%


### PR DESCRIPTION
With this change, it's easier to draft an upgrade guide without exposing it on the public site. Omitting either (or both) of the front matter fields defining the applicable version range will cause the "Installing" page to omit that guide from the list.

It's also good for safety, since empty fields are treated as 0 by the Liquid code that generates the list, meaning a guide with a missing field may incorrectly show "Willie" instead of "Sopel", and that with a missing version number. It's safer to just leave out entries missing required field data (and it's impossible to throw an error from Liquid).