### PR TITLE
Substitute Libera Chat for references to freenode

### DIFF
--- a/404.md
+++ b/404.md
@@ -6,6 +6,6 @@ center-text: true
 
 ## The file you asked for does not exist
 
-If you think it should, come to [#sopel](irc://irc.freenode.net/#sopel
-) on Freenode and tell us, or [open an issue](
-https://github.com/sopel-irc/sopel.chat/issues/new).
+If you think it should, come to [#sopel](irc://irc.libera.chat/#sopel) on
+Libera Chat and tell us, or
+[open an issue](https://github.com/sopel-irc/sopel.chat/issues/new).

--- a/_upgrading/sopel-7.md
+++ b/_upgrading/sopel-7.md
@@ -84,13 +84,13 @@ database type with a bit of search-fu. Sopel's database support is built on
 SQLAlchemy, which has [ample documentation][sqlalchemy-dialects] of its own
 about getting up and running with various back-ends.
 
-Please don't hesitate to offer feedback in [our IRC channel][sopel-freenode] or
+Please don't hesitate to offer feedback in [our IRC channel][sopel-channel] or
 [a GitHub issue][gh-new-issue]. This is a huge feature, and with a small team
 it's simply not possible for us to test everything—especially the less common
 database types (paid ones like Oracle, especially).
 
 [gh-new-issue]: https://github.com/sopel-irc/sopel/issues/new
-[sopel-freenode]: irc://chat.freenode.net/sopel
+[sopel-channel]: irc://irc.libera.chat/sopel
 [sqlalchemy-dialects]: https://docs.sqlalchemy.org/en/13/dialects/index.html
 
 
@@ -449,7 +449,7 @@ title="Tab-Separated Values">TSV</abbr>, and they can be merged by hand
 meaningful, unique entries.
 
 And of course, if you need more in-depth assistance with fixing a failed
-migration, [our IRC channel][sopel-freenode] always welcomes questions.
+migration, [our IRC channel][sopel-channel] always welcomes questions.
 
 ### Core plugin removals
 

--- a/_usage/per-channel-configuration.md
+++ b/_usage/per-channel-configuration.md
@@ -50,4 +50,4 @@ names makes it possible to disable things like URL handlers, too.
 *Note: A future version of Sopel might move to a YAML config file format instead
 of the INI format it uses now, to simplify the inclusion of more complex,
 structured options like this. Let us know [on
-IRC](irc://irc.freenode.net/#sopel) if you think this is a good idea.*
+IRC](irc://irc.libera.chat/#sopel) if you think this is a good idea.*

--- a/index.md
+++ b/index.md
@@ -65,8 +65,8 @@ Sopel's source code.
 <dl class="faq">
 <dt>Where can I report a problem with Sopel?</dt>
 <dd>You can file a ticket in our <a href="{{ site.repo }}/issues">GitHub issue
-tracker</a>, or join the developers in <a href="irc://irc.freenode.net/#sopel">
-#sopel</a> on Freenode.</dd>
+tracker</a>, or join the developers in <a href="irc://irc.libera.chat/#sopel">
+#sopel</a> on Libera Chat.</dd>
 
 <dt>Is there somewhere I can go to find plugins other people have written for
 Sopel?</dt>


### PR DESCRIPTION
Tin. I won't link to any of the drama from here, but suffice it to say we have some compelling reasons to consider this move.