### PR TITLE
redirects: add shortcut to main-repo issue 1415 for search plugin

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,8 +4,10 @@
 https://sopel.netlify.com/* https://sopel.chat/:splat 301!
 
 # Shortcuts used in plugins
-## search
-/site-op https://github.com/sopel-irc/sopel/issues/1415 302
+## issues
+/i/* https://github.com/sopel-irc/sopel/issues/:splat 302
+## pull requests
+/p/* https://github.com/sopel-irc/sopel/pull/:splat 302
 
 # YAML front-matter-based redirects for renamed pages
 {% for collection in site.collections

--- a/_redirects
+++ b/_redirects
@@ -3,6 +3,10 @@
 # Redirect default Netlify subdomain to primary domain
 https://sopel.netlify.com/* https://sopel.chat/:splat 301!
 
+# Shortcuts used in plugins
+## search
+/site-op https://github.com/sopel-irc/sopel/issues/1415 302
+
 # YAML front-matter-based redirects for renamed pages
 {% for collection in site.collections
   %}{% for page in collection.docs


### PR DESCRIPTION
This plugin currently uses a git.io link that will almost certainly vanish someday. GitHub has not committed to any particular timeline of support (or the end thereof) for existing git.io links, since announcing that new links can no longer be created.