### PR TITLE
Update links to new documentation

### DIFF
--- a/_appendices/phenny-compatibility.md
+++ b/_appendices/phenny-compatibility.md
@@ -21,7 +21,7 @@ These are likely to affect many or all plugins and deployments.
 ### Minor issues
 These only affect a small number of plugins, and/or will fail gracefully
 
-* Phenny's `last_seen_uri` and `seen` are replaced by Sopel's [memory system]({{ site.docs }}bot.html#sopel.bot.Sopel.memory). Plugins using them will likely still work, but may not interoperate with newer plugins as expected.
+* Phenny's `last_seen_uri` and `seen` are replaced by Sopel's [memory system]({{ site.docs }}package/bot.html#sopel.bot.Sopel.memory). Plugins using them will likely still work, but may not interoperate with newer plugins as expected.
 * `phenny.stats` will be an empty dict, which will negatively impact any plugin which uses it. This is likely limited to the `.stats` command in Phenny's `info` plugin.
 * Imports of `icao` are broken, as `icao.py` is not included in Sopel. This likely only breaks phenny's weather plugin, the functionality of which is replaced and improved in the third-party PyPI package [sopel-modules.weather](https://pypi.org/projects/sopel-modules.weather/).
 * Imports of `bot` and `irc` are broken. There is not necessarily a simple solution, but the only plugin this is likely to affect is `reload`, the functionality of which is replaced and improved in Sopel.

--- a/_redirects
+++ b/_redirects
@@ -37,3 +37,13 @@ https://sopel.netlify.com/* https://sopel.chat/:splat 301!
 /tutorials/* /docs/plugin.html 301
 # Specific appendix pages that have been superseded
 /appendix/formatting/ /docs/plugin/bot.html#do-it-with-style 301
+
+# Moving package documentation to its own folder
+/docs/api.html /docs/package/api.html 301
+/docs/bot.html /docs/package/bot.html 301
+/docs/config.html /docs/package/config.html 301
+/docs/db.html /docs/package/db.html 301
+/docs/irc.html /docs/package/irc.html 301
+/docs/lifecycle.html /docs/package/lifecycle.html 301
+/docs/plugin/internals.html /docs/package/plugins.html 301
+/docs/trigger.html /docs/package/trigger.html 301

--- a/_upgrading/sopel-7.md
+++ b/_upgrading/sopel-7.md
@@ -220,9 +220,9 @@ release the migration as part of your next version bump. The choice is yours;
 we just provide the tools you need to get started.
 
   [commit-adding-nick-class]: https://github.com/sopel-irc/sopel/commit/f8ca0b9
-  [docs-db-get-channel-slug]: /docs/db.html#sopel.db.SopelDB.get_channel_slug
-  [docs-identifier-lower]: /docs/api.html#sopel.tools.Identifier._lower
-  [docs-identifier-lower-swapped]: /docs/api.html#sopel.tools.Identifier._lower_swapped
+  [docs-db-get-channel-slug]: /docs/package/db.html#sopel.db.SopelDB.get_channel_slug
+  [docs-identifier-lower]: /docs/package/tools/identifiers.html#sopel.tools.identifiers.Identifier._lower
+  [docs-identifier-lower-swapped]: /docs/package/tools/identifiers.html#sopel.tools.identifiers.Identifier._lower_swapped
 
 ### Accessing the database
 
@@ -247,11 +247,11 @@ to update your plugin's documentation to warn users that non-SQLite databases
 haven't been tested, or make sure the plugin is marked as compatible with Sopel
 <7.0 only until it can be tested and/or updated.
 
-  [docs-db]: /docs/db.html
-  [docs-db-connect]: /docs/db.html#sopel.db.SopelDB.connect
-  [docs-db-execute]: /docs/db.html#sopel.db.SopelDB.execute
-  [docs-db-get_uri]: /docs/db.html#sopel.db.SopelDB.get_uri
-  [docs-db-session]: /docs/db.html#sopel.db.SopelDB.session
+  [docs-db]: /docs/package/db.html
+  [docs-db-connect]: /docs/package/db.html#sopel.db.SopelDB.connect
+  [docs-db-execute]: /docs/package/db.html#sopel.db.SopelDB.execute
+  [docs-db-get_uri]: /docs/package/db.html#sopel.db.SopelDB.get_uri
+  [docs-db-session]: /docs/package/db.html#sopel.db.SopelDB.session
 
 ### Managing URL callbacks
 

--- a/_usage/command-line-arguments.md
+++ b/_usage/command-line-arguments.md
@@ -3,8 +3,8 @@ title: Command-line arguments
 migrated: true
 source: wiki
 order: -9001
-redirect_to: /docs/cli.html
+redirect_to: /docs/run/cli.html
 ---
 
 <!-- WARNING: Update both paths (`redirect_to` above and `link` below) in parallel! -->
-Sopel's command-line argument documentation has [moved]({% link /docs/cli.html %}).
+Sopel's command-line argument documentation has [moved]({% link /docs/run/cli.html %}).

--- a/_usage/installing.md
+++ b/_usage/installing.md
@@ -111,8 +111,8 @@ brackets, that's the default setting, and you can just hit enter to keep it.
 When asked for the channels to connect to, enter them separated by commas
 (e.g. `#spam,#eggs,#cheese`) This wizard doesn't cover every option, only the
 ones which are needed to get the bot running. The core config settings are all
-[documented]({{ site.docs }}config.html#the-core-configuration-section),
-if you want to make other tweaks.
+[documented]({{ site.docs }}configuration.html), if you want to make other
+tweaks.
 
 Finally, it will ask you about configuration settings for plugins. This will
 automatically detect what plugins you have available, and run their
@@ -151,7 +151,12 @@ Of course, you can also write your own custom plugins! Check out the
 
 Most IRC networks have a service that allows you to authenticate yourself as
 the owner of a username. This is configurable in Sopel with these settings:
-[`auth_method`]({{ site.docs }}config.html#sopel.config.core_section.CoreSection.auth_method),
-[`auth_password`]({{ site.docs }}config.html#sopel.config.core_section.CoreSection.auth_password),
-[`auth_target`]({{ site.docs }}config.html#sopel.config.core_section.CoreSection.auth_target),
-and [`auth_username`]({{ site.docs }}config.html#sopel.config.core_section.CoreSection.auth_username).
+[`auth_method`]({{ site.docs }}package/config/core_section.html#sopel.config.core_section.CoreSection.auth_method),
+[`auth_password`]({{ site.docs }}package/config/core_section.html#sopel.config.core_section.CoreSection.auth_password),
+[`auth_target`]({{ site.docs }}package/config/core_section.html#sopel.config.core_section.CoreSection.auth_target),
+and [`auth_username`]({{ site.docs }}package/config/core_section.html#sopel.config.core_section.CoreSection.auth_username).
+
+You can read more about [authentication configuration](config-auth) in the
+documentation.
+
+  [config-auth] /docs/configuration.html#authentication

--- a/_usage/per-channel-configuration.md
+++ b/_usage/per-channel-configuration.md
@@ -35,9 +35,9 @@ plugin (while still allowing `.duck`). Details for each option below.
 
 The `disable_plugins` option is a simple comma-separated list of plugin names,
 just like [`core.enable`]({{ site.docs
-}}config.html#sopel.config.core_section.CoreSection.enable) or
+}}package/config/core_section.html#sopel.config.core_section.CoreSection.enable) or
 [`core.exclude`]({{ site.docs
-}}config.html#sopel.config.core_section.CoreSection.exclude).
+}}package/config/core_section.html#sopel.config.core_section.CoreSection.exclude).
 
 ### `disable_commands`
 


### PR DESCRIPTION
This is related to [PR 2257 of sopel-irc/sopel](https://github.com/sopel-irc/sopel/pull/2257) repo.

I tried to find all the possible links, so I may have miss some. The main two changes being:

* db.html is now in package/db.html
* config.html is now in package/config.html and the core section has its own file too

I also added a few links because I think they are appropriate and in-line with a more user-friendly approach to documentation.