### PR TITLE
installing: fix erroneous clone command

### DIFF
--- a/_usage/installing.md
+++ b/_usage/installing.md
@@ -51,7 +51,7 @@ latest source below.
 ### Latest source
 
 First, either clone the repository with `git clone
-git://github.com/sopel-irc/sopel.git` or download a [source zip from GitHub]({{
+https://github.com/sopel-irc/sopel.git` or download a [source zip from GitHub]({{
 site.repo }}/archive/refs/heads/master.zip).
 
 In the source directory (whether cloned or extracted from the zipfile), run


### PR DESCRIPTION
The old web documentation gives a `git-clone` command that uses the `git://` scheme, which is I think always incorrect for GitHub, and prone to [mislead users](https://github.com/sopel-irc/sopel/issues/2517).

This changeset brings the web docs in line with the [current `README`](https://github.com/sopel-irc/sopel/blob/df2009e2ad5f084c71d9017ee8f3f71b359c5a3d/README.rst?plain=1#L28-L32).

Fixes #43