### PR TITLE
usage: update "Making Sopel ignore people" page for 8.x

### DIFF
--- a/_usage/ignoring-people.md
+++ b/_usage/ignoring-people.md
@@ -1,20 +1,27 @@
 ---
 title: Making Sopel ignore people
-migrated: true
 source: wiki
 order: 100
 ---
 
-Sopel has a built-in ability to ignore specified people. This is managed through the `.blocks` command. Sopel can block by either nickname or hostmask.
+Sopel has a built-in ability to ignore specified users by either nickname or
+hostname. Bot admins can manage Sopel's ignores using the `.blocks` command.
 
-Both the nicks and the hostmasks you give to Sopel use regular expressions. If you're just looking to block a specific name (like you might if you want to block another bot), you don't need to worry about this. Otherwise, refer to [this page](https://docs.python.org/2/library/re.html) for details about the syntax.
+Both the nicknames and the hostnames you give to Sopel use regular expressions.
+If you're just looking to block a specific name (like you might if you want to
+block another bot), you don't need to worry about this. Otherwise, refer to
+[this page](https://docs.python.org/3/library/re.html) for the syntax.
 
-The `.blocks` command is used by giving it one of three different commands: `list`, `add`, and `del`. These list all blocks, add a block, or delete a block respectively. After that, it takes an argument of either `nick` or `hostmask`, indicating whether you want to list/add/delete nick or hostmask blocks. `add` and `del` both take a final argument, the nick or hostmask block that you want to add/delete.
+The `.blocks` command is used by giving it one of the three main
+subcommands—`list`, `add`, and `del`—followed by `nick` or `host` to indicate
+whether you want to list/add/delete nickname or hostname blocks. `add` and `del`
+both require a final argument: the nick or host pattern that you want to
+add/delete.
 
 ```
 .blocks add nick somenickhere
 .blocks del nick somenickhere
-.blocks add hostmask .*@.*\.bad\.actor\.net
+.blocks add host .*\.bad\.actor\.net
 .blocks list nick
-.blocks list hostmask
+.blocks list host
 ```


### PR DESCRIPTION
We don't have "hostmask" blocks any more; only "host". This is part of a fairly long saga to sane-ify the `.blocks` command (sopel-irc/sopel#1355).