### PR TITLE
Replace `imp` with `importlib` in `document_sopel_plugins.py` script

### DIFF
--- a/document_sopel_plugins.py
+++ b/document_sopel_plugins.py
@@ -11,10 +11,10 @@ Licensed under the Eiffel Forum License 2.
 https://sopel.chat
 """
 import argparse
+from importlib.machinery import SourceFileLoader
 import inspect
 import operator
 import os
-import imp
 import sys
 try:
     import sopel
@@ -113,7 +113,8 @@ def main(argv=None):
     print("Done!")
 
 def document_plugin(plugin_file, f):
-    try: plugin = imp.load_source(os.path.basename(plugin_file)[:-3], plugin_file)
+    try:
+        plugin = SourceFileLoader(os.path.basename(plugin_file)[:-3], plugin_file).load_module()
     except Exception as e:
         print ("Error loading %s: %s\nThis plugin will not be documented."
                % (plugin_file, e))


### PR DESCRIPTION
We will need this when modernizing the site build; Python 3.12 removed the `imp` module from stdlib.

It already trips me up when testing other modifications using the build script in Gitpod, since their instances default to py3.12.

_**Edit:** Same old thing about forgetting to rebase the branch so #48 is included because Netlify builds HEAD instead of the merge result. I may never learn…_